### PR TITLE
Check if db exists before init

### DIFF
--- a/server/db/index.js
+++ b/server/db/index.js
@@ -14,16 +14,29 @@ r.getNewConnection = function () {
       return conn;
     });
 };
+// Second run always fail. Create conditionally
+r.getNewConnection().then(conn=> {
+    r
+        .dbList()
+        .contains(config.get('rethinkdb').db)
+        .run(conn, (err, exists)=>{
+        console.log("[rse]",config.get('rethinkdb').db, err, exists);
+        if (!exists) {
 
-r.init(config.get('rethinkdb'), [
-  {
-    name: 'users',
-    indexes: ['login']
-  }
-]).then(function (conn) {
-  r.conn = conn;
-  r.connections.push(conn);
-  r.conn.use(config.get('rethinkdb').db);
-});
+            r.init(config.get('rethinkdb'), [
+                {
+                    name: 'users',
+                    indexes: ['login']
+                }
+            ]).then(function (conn) {
+                r.conn = conn;
+                r.connections.push(conn);
+                r.conn.use(config.get('rethinkdb').db);
+            });
+
+        }
+    })
+})
+
 
 module.exports = r;


### PR DESCRIPTION
My first run had an issue and npm crash but the db was created, any subsequent try to run npm resulted in:
```
Unhandled rejection ReqlOpFailedError: Database `passport_rethinkdb_tutorial` already exists in:
r.dbCreate("passport_rethinkdb_tutorial")
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    at ReqlOpFailedError.ReqlError [as constructor] (/home/itzco/Tech/github/passport-rethinkdb-tutorial/node_modules/rethinkdb/errors.js:23:13)
```
This was the least invasive fix I could think of. Also application should be able to run with init only working on db not existing.