### PR TITLE
Check if db exists before init

### DIFF
--- a/server/db/index.js
+++ b/server/db/index.js
@@ -15,15 +15,31 @@ r.getNewConnection = function () {
     });
 };
 
-r.init(config.get('rethinkdb'), [
-  {
-    name: 'users',
-    indexes: ['login']
-  }
-]).then(function (conn) {
-  r.conn = conn;
-  r.connections.push(conn);
-  r.conn.use(config.get('rethinkdb').db);
-});
+r.getNewConnection().then(conn=> {
+    r
+        .dbList()
+        .contains(config.get('rethinkdb').db)
+        .run(conn, (err, exists)=>{
+        if (!exists) {
+
+            r.init(config.get('rethinkdb'), [
+                {
+                    name: 'users',
+                    indexes: ['login']
+                }
+            ]).then(function (conn) {
+                r.conn = conn;
+                r.connections.push(conn);
+                r.conn.use(config.get('rethinkdb').db);
+            });
+
+        } else {
+            r.conn = conn;
+            r.connections.push(conn);
+            r.conn.use(config.get('rethinkdb').db);
+        }
+    })
+})
+
 
 module.exports = r;


### PR DESCRIPTION
Initial run failed but db was created, on running npm run dev again it always got db already exists. This fixes the problem. When db exists it will still register a connection.

```
Unhandled rejection ReqlOpFailedError: Database `passport_rethinkdb_tutorial` already exists in:
r.dbCreate("passport_rethinkdb_tutorial")
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    at ReqlOpFailedError.ReqlError [as constructor] (/home/itzco/Tech/github/passport-rethinkdb-tutorial/node_modules/rethinkdb/errors.js:23:13)
```